### PR TITLE
Set default TTL for all Redis cache writes using config value

### DIFF
--- a/.todos.md
+++ b/.todos.md
@@ -12,5 +12,5 @@ Filtros de mensagens publicadas
 -> SALVAR dados arquivados
 -> Grafana conectado no banco e redis
 -> Grafana conectado com a api
--> Validar a aplicação para ver se todos lugares que salvam no redis estão com TTL
-->
+-> ✅ Validar a aplicação para ver se todos lugares que salvam no redis estão com TTL >> OK
+-> Conseguir rodar asynq e google pubsub juntos para consigurações específicas

--- a/internal/asynqstore/cache_store.go
+++ b/internal/asynqstore/cache_store.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/IsaacDSC/gqueue/internal/asynqtask"
+	"github.com/IsaacDSC/gqueue/internal/cfg"
 	"github.com/IsaacDSC/gqueue/internal/domain"
 	"github.com/redis/go-redis/v9"
 )
@@ -126,7 +127,8 @@ func (c Cache) SetArchivedTasks(ctx context.Context, events []domain.Event) erro
 		return fmt.Errorf("failed to marshal events: %w", err)
 	}
 
-	if err := c.cache.Set(ctx, archivedKey, b, -1).Err(); err != nil {
+	conf := cfg.Get()
+	if err := c.cache.Set(ctx, archivedKey, b, conf.Cache.DefaultTTL).Err(); err != nil {
 		return fmt.Errorf("failed to set archived tasks: %w", err)
 	}
 

--- a/internal/cfg/env.go
+++ b/internal/cfg/env.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/ilyakaznacheev/cleanenv"
 )
@@ -28,7 +29,8 @@ type ConfigDatabase struct {
 }
 
 type Cache struct {
-	CacheAddr string `env:"CACHE_ADDR"`
+	CacheAddr  string        `env:"CACHE_ADDR"`
+	DefaultTTL time.Duration `env:"CACHE_DEFAULT_TTL" default:"24h"`
 }
 
 type AsynqConfig struct {

--- a/internal/storests/base.go
+++ b/internal/storests/base.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/IsaacDSC/gqueue/internal/cfg"
 	"github.com/redis/go-redis/v9"
 )
 
@@ -31,5 +32,10 @@ func (s *Store) key(typeEvent string, values ...string) string {
 
 func (s *Store) groupInsights(ctx context.Context, key string) error {
 	k := s.key("group-insights")
-	return s.cache.SAdd(ctx, k, key).Err()
+	if err := s.cache.SAdd(ctx, k, key).Err(); err != nil {
+		return err
+	}
+
+	conf := cfg.Get()
+	return s.cache.Expire(ctx, k, conf.Cache.DefaultTTL).Err()
 }

--- a/internal/storests/w_consumed.go
+++ b/internal/storests/w_consumed.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/IsaacDSC/gqueue/internal/cfg"
 	"github.com/IsaacDSC/gqueue/internal/domain"
 	"github.com/redis/go-redis/v9"
 )
@@ -29,6 +30,11 @@ func (s *Store) Consumed(ctx context.Context, input domain.ConsumerMetric) error
 	now := time.Now().UTC().UnixMilli()
 	if err := s.cache.ZAdd(ctx, key, redis.Z{Score: float64(now), Member: payload}).Err(); err != nil {
 		return fmt.Errorf("failed to save consumed event: %w", err)
+	}
+
+	conf := cfg.Get()
+	if err := s.cache.Expire(ctx, key, conf.Cache.DefaultTTL).Err(); err != nil {
+		return fmt.Errorf("failed to set TTL for consumed event: %w", err)
 	}
 
 	return nil

--- a/internal/storests/w_published.go
+++ b/internal/storests/w_published.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/IsaacDSC/gqueue/internal/cfg"
 	"github.com/IsaacDSC/gqueue/internal/domain"
 	"github.com/redis/go-redis/v9"
 )
@@ -29,6 +30,11 @@ func (s *Store) Published(ctx context.Context, input domain.PublisherMetric) err
 	now := time.Now().UTC().UnixMilli()
 	if err := s.cache.ZAdd(ctx, key, redis.Z{Score: float64(now), Member: payload}).Err(); err != nil {
 		return fmt.Errorf("failed to save publisher event: %w", err)
+	}
+
+	conf := cfg.Get()
+	if err := s.cache.Expire(ctx, key, conf.Cache.DefaultTTL).Err(); err != nil {
+		return fmt.Errorf("failed to set TTL for publisher event: %w", err)
 	}
 
 	return nil

--- a/pkg/cachemanager/cache_strategy.go
+++ b/pkg/cachemanager/cache_strategy.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/IsaacDSC/gqueue/internal/cfg"
 	redis "github.com/redis/go-redis/v9"
 )
 
@@ -43,7 +44,8 @@ func (s Strategy) Key(params ...string) Key {
 
 // GetDefaultTTL for cache entries, can be adjusted as needed.
 func (s Strategy) GetDefaultTTL() time.Duration {
-	return 24 * time.Hour
+	conf := cfg.Get()
+	return conf.Cache.DefaultTTL
 }
 
 // Hydrate executes the provided function, stores its result in the cache, and unmarshals it into value.
@@ -141,7 +143,8 @@ func (s Strategy) IncrementValue(ctx context.Context, key Key, value any) error 
 		return fmt.Errorf("error marshalling value for key %s: %w", key.String(), err)
 	}
 
-	if err := s.client.Set(ctx, key.String(), b, -1).Err(); err != nil {
+	conf := cfg.Get()
+	if err := s.client.Set(ctx, key.String(), b, conf.Cache.DefaultTTL).Err(); err != nil {
 		return fmt.Errorf("error setting value for key %s: %w", key.String(), err)
 	}
 


### PR DESCRIPTION
This pull request improves the consistency and configurability of Redis cache expiration (TTL) throughout the application. It introduces a centralized `DefaultTTL` configuration for cache entries, ensuring that all relevant Redis operations use this value instead of hardcoded or infinite TTLs. 